### PR TITLE
Fix notes.json not being gitignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+NotesHandler/notes.json


### PR DESCRIPTION
Without this, it will always tell people updating failed and they'll have to use force update every time.